### PR TITLE
Replace tensorboardX with torch.utils.tensorboard

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 torch>=1.7
 coqpit
 fsspec
-tensorboardX
 soundfile

--- a/trainer/logging/tensorboard_logger.py
+++ b/trainer/logging/tensorboard_logger.py
@@ -1,6 +1,6 @@
 import traceback
 
-from tensorboardX import SummaryWriter
+from torch.utils.tensorboard import SummaryWriter
 
 from trainer.logging.base_dash_logger import BaseDashboardLogger
 


### PR DESCRIPTION
When we use tensorboardx with pytorch-1.11, it throws ImportError like this https://github.com/pytorch/pytorch/issues/67151.

pytorch supports tensorboard .
https://pytorch.org/docs/stable/tensorboard.html

This pr replaces tensorboardX with torch.utils.tensorboard of pytorch.