### PR TITLE
type correction to `gpus` list

### DIFF
--- a/trainer/distribute.py
+++ b/trainer/distribute.py
@@ -27,7 +27,7 @@ def distribute():
     # set active gpus from CUDA_VISIBLE_DEVICES or --gpus
     if "CUDA_VISIBLE_DEVICES" in os.environ:
         num_gpus = torch.cuda.device_count()
-        gpus = range(num_gpus)
+        gpus = [str(gpu) for gpu in range(num_gpus)]
     else:
         gpus = args.gpus.split(",")
         num_gpus = len(gpus)


### PR DESCRIPTION
`','.join(gpus)` needs a list of strings instead of a list of ints. The script no longer exists with type error, when `range(num_gpus)` used for `gpus`.