### PR TITLE
minimal fix to wandb_logger.py necessary to get Overflow running using wandb

### DIFF
--- a/trainer/logging/wandb_logger.py
+++ b/trainer/logging/wandb_logger.py
@@ -1,7 +1,9 @@
 # pylint: disable=W0613
 
 import traceback
+from typing import Dict, Union
 from pathlib import Path
+from collections import defaultdict
 
 from trainer.logging.base_dash_logger import BaseDashboardLogger
 from trainer.trainer_utils import is_wandb_available
@@ -20,46 +22,55 @@ class WandbLogger(BaseDashboardLogger):
         self.run = None
         self.run = wandb.init(**kwargs) if not wandb.run else wandb.run
         self.model_name = self.run.config.model
-        self.log_dict = {}
+        # dictionary of dictionaries - record stats per step
+        self.log_dict = defaultdict(dict)
 
-    def model_weights(self, model):
+    def model_weights(self, model, step):
         layer_num = 1
         for name, param in model.named_parameters():
             if param.numel() == 1:
-                self.add_scalars("weights", {"layer{}-{}/value".format(layer_num, name): param.max()})
+                self.add_scalars("weights", {"layer{}-{}/value".format(layer_num, name): param.max()}, step)
             else:
-                self.add_scalars("weights", {"layer{}-{}/max".format(layer_num, name): param.max()})
-                self.add_scalars("weights", {"layer{}-{}/min".format(layer_num, name): param.min()})
-                self.add_scalars("weights", {"layer{}-{}/mean".format(layer_num, name): param.mean()})
-                self.add_scalars("weights", {"layer{}-{}/std".format(layer_num, name): param.std()})
-                self.log_dict["weights/layer{}-{}/param".format(layer_num, name)] = wandb.Histogram(param)
-                self.log_dict["weights/layer{}-{}/grad".format(layer_num, name)] = wandb.Histogram(param.grad)
+                self.add_scalars("weights", {"layer{}-{}/max".format(layer_num, name): param.max()}, step)
+                self.add_scalars("weights", {"layer{}-{}/min".format(layer_num, name): param.min()}, step)
+                self.add_scalars("weights", {"layer{}-{}/mean".format(layer_num, name): param.mean()}, step)
+                self.add_scalars("weights", {"layer{}-{}/std".format(layer_num, name): param.std()}, step)
+                self.log_dict[step]["weights/layer{}-{}/param".format(layer_num, name)] = wandb.Histogram(param)
+                self.log_dict[step]["weights/layer{}-{}/grad".format(layer_num, name)] = wandb.Histogram(param.grad)
             layer_num += 1
 
-    def add_scalars(self, scope_name, stats):
-        for key, value in stats.items():
-            self.log_dict["{}/{}".format(scope_name, key)] = value
+    def add_scalars(self, scope_name, scalars, step):
+        for key, value in scalars.items():
+            self.log_dict[step]["{}/{}".format(scope_name, key)] = value
 
-    def add_figures(self, scope_name, figures):
+    def add_figures(self, scope_name, figures, step):
         for key, value in figures.items():
-            self.log_dict["{}/{}".format(scope_name, key)] = wandb.Image(value)
+            self.log_dict[step]["{}/{}".format(scope_name, key)] = wandb.Image(value)
 
-    def add_audios(self, scope_name, audios, sample_rate):
+    def add_audios(self, scope_name, audios, step, sample_rate):
         for key, value in audios.items():
             if value.dtype == "float16":
                 value = value.astype("float32")
             try:
-                self.log_dict["{}/{}".format(scope_name, key)] = wandb.Audio(value, sample_rate=sample_rate)
+                self.log_dict[step]["{}/{}".format(scope_name, key)] = wandb.Audio(value, sample_rate=sample_rate)
             except RuntimeError:
                 traceback.print_exc()
 
-    def log(self, log_dict, prefix="", flush=False):
-        for key, value in log_dict.items():
-            self.log_dict[prefix + key] = value
-        if flush:  # for cases where you don't want to accumulate data
-            self.flush()
-
     def add_text(self, title, text, step):
+        pass
+
+    def add_scalar(self, title: str, value: float, step: int) -> None:
+        pass
+
+    def add_figure(
+        self,
+        title: str,
+        figure: Union["matplotlib.figure.Figure", "plotly.graph_objects.Figure"],
+        step: int,
+    ) -> None:
+        pass
+
+    def add_audio(self, title: str, audio: "np.ndarray", step: int, sample_rate: int) -> None:
         pass
 
     @rank_zero_only
@@ -68,8 +79,9 @@ class WandbLogger(BaseDashboardLogger):
 
     def flush(self):
         if self.run:
-            wandb.log(self.log_dict)
-        self.log_dict = {}
+            for step in sorted(self.log_dict.keys()):
+                wandb.log(self.log_dict[step], step)
+        self.log_dict.clear()
 
     def finish(self):
         if self.run:
@@ -86,4 +98,4 @@ class WandbLogger(BaseDashboardLogger):
         elif data_path.is_file():
             artifact.add_file(str(data_path))
 
-        self.run.add_artifact(artifact, aliases=aliases)
+        self.run.log_artifact(artifact, aliases=aliases)

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -704,22 +704,6 @@ class Trainer:
         logger.info(" > Restoring from %s ...", os.path.basename(restore_path))
         checkpoint = load_fsspec(restore_path, map_location="cpu")
 
-        # if old-style GAN checkpoint
-        if 'model_disc' in checkpoint:
-            # fix up the checkpoint to modern format
-            model_g = checkpoint['model']
-            model_d = checkpoint['model_disc']
-            model_g = {'model_g.' + k : v for k,v in model_g.items()}
-            model_d = {'model_d.' + k : v for k,v in model_d.items()}
-            model_dict = {**model_g, **model_d}
-            # replace separate entries  by lists, expecting discriminator first
-            optimizers = [checkpoint['optimizer_disc'], checkpoint['optimizer']]
-            schedulers = [checkpoint['scheduler_disc'], checkpoint['scheduler']]
-
-            del checkpoint['model_disc'], checkpoint['optimizer_disc'], checkpoint['scheduler_disc']
-            checkpoint['model'] = model_dict
-            checkpoint['optimizer'] = optimizers
-            checkpoint['schedulers'] = schedulers
         try:
             logger.info(" > Restoring Model...")
             model.load_state_dict(checkpoint["model"])

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -703,6 +703,23 @@ class Trainer:
 
         logger.info(" > Restoring from %s ...", os.path.basename(restore_path))
         checkpoint = load_fsspec(restore_path, map_location="cpu")
+
+        # if old-style GAN checkpoint
+        if 'model_disc' in checkpoint:
+            # fix up the checkpoint to modern format
+            model_g = checkpoint['model']
+            model_d = checkpoint['model_disc']
+            model_g = {'model_g.' + k : v for k,v in model_g.items()}
+            model_d = {'model_d.' + k : v for k,v in model_d.items()}
+            model_dict = {**model_g, **model_d}
+            # replace separate entries  by lists, expecting discriminator first
+            optimizers = [checkpoint['optimizer_disc'], checkpoint['optimizer']]
+            schedulers = [checkpoint['scheduler_disc'], checkpoint['scheduler']]
+
+            del checkpoint['model_disc'], checkpoint['optimizer_disc'], checkpoint['scheduler_disc']
+            checkpoint['model'] = model_dict
+            checkpoint['optimizer'] = optimizers
+            checkpoint['schedulers'] = schedulers
         try:
             logger.info(" > Restoring Model...")
             model.load_state_dict(checkpoint["model"])


### PR DESCRIPTION
WandB logger has been broken at least since March 19th, 2022. As far as I understand, the API for loggers changed a bit and the WandB logger was never updated. See [issue 19](https://github.com/coqui-ai/Trainer/issues/19).

I really wanted to log to WandB, so I did the minimum necessary change to the logger in order to get it to work for the specific recipe I'm using in Coqui-TTS (Overflow). All the singular-item logging methods are not implemented.