### PR TITLE
fix bug in restore_model that crashes when loading existing GAN checkpoints from Coqui TTS

### DIFF
--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -694,7 +694,7 @@ class Trainer:
             if isinstance(obj, list):
                 for idx, state in enumerate(states):
                     obj[idx].load_state_dict(state)
-            if isinstance(obj, dict):
+            elif isinstance(obj, dict):
                 for key, state in states.items():
                     obj[key].load_state_dict(state)
             else:


### PR DESCRIPTION
The bug is triggered when the field `'optimizer'` in the checkpoint dictionary is a list, such as with GAN models where it's a list of 2 states, one for D optimizer and one for G optimizer.