### PR TITLE
Bug fix on cpu autocast

### DIFF
--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -995,7 +995,7 @@ class Trainer:
 
     def _get_autocast_args(self, mixed_precision: bool):
         device = "cpu"
-        dtype = None
+        dtype = torch.get_autocast_cpu_dtype()
         if self.use_cuda:
             device = "cuda"
             dtype = torch.float16 if mixed_precision else torch.float32


### PR DESCRIPTION

The autocasting dtype was being set to None. Because of it  CPU training was broken with the following error:
```

Traceback (most recent call last):
  File "/home/edresson/.local/lib/python3.8/site-packages/trainer/trainer.py", line 1650, in fit
    self._fit()
  File "/home/edresson/.local/lib/python3.8/site-packages/trainer/trainer.py", line 1602, in _fit
    self.train_epoch()
  File "/home/edresson/.local/lib/python3.8/site-packages/trainer/trainer.py", line 1336, in train_epoch
    outputs, _ = self.train_step(batch, batch_num_steps, cur_step, loader_start_time)
  File "/home/edresson/.local/lib/python3.8/site-packages/trainer/trainer.py", line 1218, in train_step
    outputs, loss_dict_new, step_time = self.optimize(
  File "/home/edresson/.local/lib/python3.8/site-packages/trainer/trainer.py", line 1061, in optimize
    with torch.autocast(device_type=device, dtype=dtype, enabled=config.mixed_precision):
  File "/home/edresson/.local/lib/python3.8/site-packages/torch/autocast_mode.py", line 169, in __enter__
    torch.set_autocast_cpu_dtype(self.fast_dtype)
TypeError: dtype must be a torch.dtype (got NoneType)

```

This PR fix the issue.
