### PR TITLE
free outputs in training loop as soon as possible as it makes a big difference in constrained-memory scenarios

### DIFF
--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -1337,6 +1337,7 @@ class Trainer:
             if outputs is None:
                 logger.info(" [!] `train_step()` retuned `None` outputs. Skipping training step.")
                 continue
+            del outputs
             loader_start_time = time.time()
 
             # RUN EVAL -> run evaluation epoch in the middle of training. Useful for big datasets.


### PR DESCRIPTION
I had an issue where training crashed consistently after about 9k steps of training OverFlow, with a dataset of about 300 batches (so it's not a "batch is too big" error. I described my issue exhaustively [on the PyTorch forums](https://discuss.pytorch.org/t/systematically-debugging-out-of-memory-issue/175034).

The crash was:
```
torch.cuda.OutOfMemoryError: CUDA out of memory. Tried to allocate 2.00 MiB (GPU 0; 23.65 GiB total capacity; 12.35 GiB already allocated; 2.56 MiB free; 22.33 GiB reserved in total by PyTorch) If reserved memory is >> allocated memory try setting max_split_size_mb to avoid fragmentation.  See documentation for Memory Management and PYTORCH_CUDA_ALLOC_CONF
```

Note: allocation attempt is 2MB, card has 24GB of RAM, 12.35GB already allocated, only 2.56MB free out of 22GB reserved.

The training loop in `train_epoch()` is:

```python
for cur_step, batch in enumerate(self.train_loader):
    outputs, _ = self.train_step(batch, batch_num_steps, cur_step, loader_start_time)
    if outputs is None:
        logger.info(" [!] `train_step()` retuned `None` outputs. Skipping training step.")
        continue
    # more stuff...
```

As far as I can tell, in each loop iteration, the memory for `outputs` can only be freed _after_ a successful call to `train_step()`, since if `train_step()` were to throw an exception for example, we would expect `outputs` to still reference the last loop iteration's outputs.

My only change was to explicitly delete the reference to `outputs` when it's no longer in use, and it solved my instability issues.

An alternative approach is to wrap the first 4 lines of the loop in a function to get proper scoping for the outputs variable, which is maybe cleaner but also more verbose.