### PR TITLE
bugfix: fix get_last_checkpoint on windows

### DIFF
--- a/trainer/io.py
+++ b/trainer/io.py
@@ -230,7 +230,9 @@ def get_last_checkpoint(path: str) -> Tuple[str, str]:
     fs = fsspec.get_mapper(path).fs
     file_names = fs.glob(os.path.join(path, "*.pth"))
     scheme = urlparse(path).scheme
-    if scheme:  # scheme is not preserved in fs.glob, add it back
+    if scheme and path.startswith(scheme + "://"):
+        # scheme is not preserved in fs.glob, add it 
+        # back if it exists on the path
         file_names = [scheme + "://" + file_name for file_name in file_names]
     last_models = {}
     last_model_nums = {}


### PR DESCRIPTION
On windows, the drive letter is determined as the scheme by `urlparse(path).scheme`. It doesn't matter if `\\` or `/` is used as a diretory separator:

```
>>> from urllib.parse import urlparse
>>> urlparse("e:\\hello").scheme
'e'
>>> urlparse("e:/hello").scheme
'e'
```

This PR fixes this issue by adding a check before attempting to readd the scheme.
The scheme is now only added if it was actually there on the incoming path.
