### PR TITLE
Update trainer.py

### DIFF
--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -1707,6 +1707,7 @@ class Trainer:
             ch = load_fsspec(self.args.restore_path, map_location="cpu")
             if "model_loss" in ch:
                 self.best_loss = ch["model_loss"]
+                self.best_loss = self.best_loss['train_loss']
             logger.info(" > Starting with loaded last best loss %f", self.best_loss)
 
     def test(self, model=None, test_samples=None) -> None:


### PR DESCRIPTION
Fix for TypeError During Training

This fix addresses an issue where a TypeError occurred during training.

The problem was that during training, when tracking the best loss (self.best_loss), there were cases where the loss value unexpectedly came in the form of a dictionary. This dictionary contained multiple values, such as "train_loss" and "eval_loss," causing subsequent comparisons to raise a TypeError.

This fix consists of two steps:

Updating the self.best_loss variable with ch["model_loss"] to ensure it contains the training loss value. Correcting the self.best_loss variable to only contain the "train_loss" value. The aim of this fix is to accurately track the best training loss value during the training process.