### PR TITLE
bugfix: distribute rank initialization

### DIFF
--- a/trainer/distribute.py
+++ b/trainer/distribute.py
@@ -46,7 +46,7 @@ def distribute():
     for rank, local_gpu_id in enumerate(gpus):
         my_env = os.environ.copy()
         my_env["PYTHON_EGG_CACHE"] = f"/tmp/tmp{local_gpu_id}"
-        my_env["RANK"] = f"{local_gpu_id}"
+        my_env["RANK"] = f"{rank}"
         my_env["CUDA_VISIBLE_DEVICES"] = f"{','.join(gpus)}"
         command[-1] = f"--rank={rank}"
         # prevent stdout for processes with rank != 0


### PR DESCRIPTION
Change RANK env variable value initialization from `local_gpu_id` to `rank`.

This change is necessary because in the current configuration, the get_rank function returns the GPU id [get_rank](https://github.com/coqui-ai/Trainer/blob/340aeac1b15e75bbc94effb1c66ad47b4dc44b5e/trainer/utils/distributed.py#L18) . As a result, the loggers fail to initialize properly, causing issues [here](https://github.com/coqui-ai/Trainer/blob/340aeac1b15e75bbc94effb1c66ad47b4dc44b5e/trainer/trainer.py#L671).