### PR TITLE
Multiples bug fixes and add on_train_epoch_start callback

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -10,7 +10,7 @@ jobs:
   build-sdist:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Verify tag matches version
         run: |
           set -ex
@@ -19,7 +19,7 @@ jobs:
           if [[ "$version" != "$tag" ]]; then
             exit 1
           fi
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
         with:
           python-version: 3.9
       - run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,9 +21,9 @@ jobs:
         python-version: [3.8, 3.9, "3.10", "3.11"]
         experimental: [false]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: coqui-ai/setup-python@pip-cache-key-py-ver
+        uses:  actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/trainer/callbacks.py
+++ b/trainer/callbacks.py
@@ -7,6 +7,8 @@ class TrainerCallback:
         self.callbacks_on_init_end = []
         self.callbacks_on_epoch_start = []
         self.callbacks_on_epoch_end = []
+        self.callbacks_on_train_epoch_start = []
+        self.callbacks_on_train_epoch_end = []
         self.callbacks_on_train_step_start = []
         self.callbacks_on_train_step_end = []
         self.callbacks_on_keyboard_interrupt = []
@@ -21,6 +23,10 @@ class TrainerCallback:
                 self.callbacks_on_epoch_start.append(value)
             elif key == "on_epoch_end":
                 self.callbacks_on_epoch_end.append(value)
+            elif key == "on_train_epoch_start":
+                self.callbacks_on_train_epoch_start.append(value)
+            elif key == "on_train_epoch_end":
+                self.callbacks_on_train_epoch_end.append(value)
             elif key == "on_train_step_start":
                 self.callbacks_on_train_step_start.append(value)
             elif key == "on_train_step_end":
@@ -100,6 +106,42 @@ class TrainerCallback:
 
         if self.callbacks_on_epoch_end:
             for callback in self.callbacks_on_epoch_end:
+                callback(trainer)
+
+    def on_train_epoch_start(self, trainer) -> None:
+        if hasattr(trainer.model, "module"):
+            if hasattr(trainer.model.module, "on_train_epoch_start"):
+                trainer.model.module.on_train_epoch_start(trainer)
+        else:
+            if hasattr(trainer.model, "on_train_epoch_start"):
+                trainer.model.on_train_epoch_start(trainer)
+
+        if hasattr(trainer.criterion, "on_train_epoch_start"):
+            trainer.criterion.on_train_epoch_start(trainer)
+
+        if hasattr(trainer.optimizer, "on_train_epoch_start"):
+            trainer.optimizer.on_train_epoch_start(trainer)
+
+        if self.callbacks_on_train_epoch_start:
+            for callback in self.callbacks_on_train_epoch_start:
+                callback(trainer)
+
+    def on_train_epoch_end(self, trainer) -> None:
+        if hasattr(trainer.model, "module"):
+            if hasattr(trainer.model.module, "on_train_epoch_end"):
+                trainer.model.module.on_train_epoch_end(trainer)
+        else:
+            if hasattr(trainer.model, "on_train_epoch_end"):
+                trainer.model.on_train_epoch_end(trainer)
+
+        if hasattr(trainer.criterion, "on_train_epoch_end"):
+            trainer.criterion.on_train_epoch_end(trainer)
+
+        if hasattr(trainer.optimizer, "on_train_epoch_end"):
+            trainer.optimizer.on_train_epoch_end(trainer)
+
+        if self.callbacks_on_train_epoch_end:
+            for callback in self.callbacks_on_train_epoch_end:
                 callback(trainer)
 
     @staticmethod

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -2112,10 +2112,10 @@ class Trainer:
         if "target_loss" in self.config and self.config.target_loss:
             if f"avg_{self.config.target_loss}" in keep_avg_target.avg_values.keys():
                 return keep_avg_target[f"avg_{self.config.target_loss}"]
-            else:
-                raise ValueError(
-                    " [!] Target loss not found in the keep_avg_target. You might be exiting the training loop before it is computed or set the target_loss in the model config incorrectly."
-                )
+
+            raise ValueError(
+                " [!] Target loss not found in the keep_avg_target. You might be exiting the training loop before it is computed or set the target_loss in the model config incorrectly."
+            )
 
         # take the average of loss_{optimizer_idx} as the target loss when there are multiple optimizers
         if isinstance(self.optimizer, list):

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -529,7 +529,7 @@ class Trainer:
         # setup optimizer
         self.optimizer = self.get_optimizer(self.model, self.config)
 
-        # If multiple-optimizer setup with grad accumulation and without custom optimize function raise an error
+        # If multiple-optimizer setup with grad accumulation and without custom optimize method raise an error
         if (
             self.grad_accum_steps != 1
             and isinstance(self.optimizer, list)
@@ -1494,6 +1494,8 @@ class Trainer:
             self.model.train()
         epoch_start_time = time.time()
 
+        self.callbacks.on_train_epoch_start(self)
+
         self.c_logger.print_train_start()
         loader_start_time = time.time()
         # TRAINING EPOCH -> iterate over the training samples
@@ -1516,6 +1518,8 @@ class Trainer:
                 torch.set_grad_enabled(True)
 
         epoch_time = time.time() - epoch_start_time
+        self.callbacks.on_train_epoch_end(self)
+
         # scheduler step
         if self.scheduler is not None and self.config.scheduler_after_epoch:
             if isinstance(self.scheduler, list):

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -443,6 +443,10 @@ class Trainer:
         if not self.config.log_model_step:
             self.config.log_model_step = self.config.save_step
 
+        # make sure that start_with_eval is disabled if eval is disabled
+        if not self.config.run_eval and self.start_with_eval:
+            self.start_with_eval = False
+
         self.total_steps_done = 0
         self.epochs_done = 0
         self.restore_step = 0

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -529,6 +529,16 @@ class Trainer:
         # setup optimizer
         self.optimizer = self.get_optimizer(self.model, self.config)
 
+        # If multiple-optimizer setup with grad accumulation and without custom optimize function raise an error
+        if (
+            self.grad_accum_steps != 1
+            and isinstance(self.optimizer, list)
+            and not isimplemented(self.model, "optimize")
+        ):
+            raise ValueError(
+                " [!] Coqui Trainer does not support grad_accum_steps for multiple-optimizer setup, please set grad_accum_steps to 1 or implement in your model a custom method called ´optimize` that need to deal with dangling gradients in multiple-optimizer setup!"
+            )
+
         # CALLBACK
         self.callbacks = TrainerCallback()
         self.callbacks.parse_callbacks_dict(callbacks)


### PR DESCRIPTION
## What it does?

1. Solve  `KeyError: 'avg_loss_1'` error when start_with_eval=True and target_loss is settled. This issue happens because the training keep_avg_target.avg_values is an empty dictionary. It is related to https://github.com/coqui-ai/TTS/issues/2862. This error also happens in training when we try to save a checkpoint before we have updated self.keep_avg_train or self.keep_avg_eval.  To solve it this PR also make _pick_target_avg_loss safe and it avoid issues like https://github.com/coqui-ai/TTS/issues/1608 to happens, if the keep_avg_target.avg_values is empty it will return None and all will be good.
2. It also raises an error if multiple-optimizer setup with grad accumulation and without a custom `optimize` method.  It avoids the user training the model with our implementation that has dangling gradients in multiple-optimizer setup with grad accumulation  (I already did it accidently, It is really bad because we can lose training time).
3. It added `on_train_epoch_start` and `on_train_epoch_end` callbacks. Currently, the only way to put modules in eval mode model during the training is via `on_train_step_start` callback, that is called each train_step. It is really slow. Adding this new callback we can do it only one time per epoch. It should decrease the step time for XTTS GPT and XTTS decoder training.

