### PR TITLE
fix: make --continue_path work again

### DIFF
--- a/tests/test_continue_train.py
+++ b/tests/test_continue_train.py
@@ -14,8 +14,19 @@ def test_continue_train():
     continue_path = max(glob.glob(os.path.join(output_path, "*/")), key=os.path.getmtime)
     number_of_checkpoints = len(glob.glob(os.path.join(continue_path, "*.pth")))
 
-    command_continue = f"python tests/utils/train_mnist.py --continue_path {continue_path}"
+    # Continue training from the best model
+    command_continue = f"python tests/utils/train_mnist.py --continue_path {continue_path} --coqpit.run_eval_steps=1"
     run_cli(command_continue)
 
     assert number_of_checkpoints < len(glob.glob(os.path.join(continue_path, "*.pth")))
+
+    # Continue training from the last checkpoint
+    for best in glob.glob(os.path.join(continue_path, "best_model*")):
+        os.remove(best)
+    run_cli(command_continue)
+
+    # Continue training from a specific checkpoint
+    restore_path = os.path.join(continue_path, "checkpoint_5.pth")
+    command_continue = f"python tests/utils/train_mnist.py --restore_path {restore_path}"
+    run_cli(command_continue)
     shutil.rmtree(continue_path)

--- a/trainer/io.py
+++ b/trainer/io.py
@@ -180,7 +180,15 @@ def save_best_model(
     save_func=None,
     **kwargs,
 ):
-    if current_loss < best_loss:
+    if (
+        current_loss["eval_loss"] is not None
+        and best_loss["eval_loss"] is not None
+        and current_loss["eval_loss"] < best_loss["eval_loss"]
+    ) or (
+        current_loss["eval_loss"] is None
+        and best_loss["eval_loss"] is None
+        and current_loss["train_loss"] < best_loss["train_loss"]
+    ):
         best_model_name = f"best_model_{current_step}.pth"
         checkpoint_path = os.path.join(out_path, best_model_name)
         logger.info(" > BEST MODEL : %s", checkpoint_path)

--- a/trainer/io.py
+++ b/trainer/io.py
@@ -180,14 +180,9 @@ def save_best_model(
     save_func=None,
     **kwargs,
 ):
-    if (
-        current_loss["eval_loss"] is not None
-        and best_loss["eval_loss"] is not None
-        and current_loss["eval_loss"] < best_loss["eval_loss"]
-    ) or (
-        current_loss["eval_loss"] is None
-        and best_loss["eval_loss"] is None
-        and current_loss["train_loss"] < best_loss["train_loss"]
+    use_eval_loss = current_loss["eval_loss"] is not None and best_loss["eval_loss"] is not None
+    if (use_eval_loss and current_loss["eval_loss"] < best_loss["eval_loss"]) or (
+        not use_eval_loss and current_loss["train_loss"] < best_loss["train_loss"]
     ):
         best_model_name = f"best_model_{current_step}.pth"
         checkpoint_path = os.path.join(out_path, best_model_name)


### PR DESCRIPTION
TLDR: fixes loading of models via `--continue_path`

# The issue

When resuming training via the `--continue_path` argument, first the following
error is logged, but training continues:
```
Traceback (most recent call last):
  File ".../lib/python3.10/logging/__init__.py", line 1100, in emit
    msg = self.format(record)
  File ".../lib/python3.10/logging/__init__.py", line 943, in format
    return fmt.format(record)
  File ".../lib/python3.10/logging/__init__.py", line 678, in format
    record.message = record.getMessage()
  File ".../lib/python3.10/logging/__init__.py", line 368, in getMessage
    msg = msg % self.args
TypeError: must be real number, not dict
Call stack:
  File ".../train_vits.py", line 120, in <module>
    trainer.fit()
  File ".../trainer/trainer.py", line 1826, in fit
    self._fit()
  File ".../trainer/trainer.py", line 1764, in _fit
    self._restore_best_loss()
  File ".../trainer/trainer.py", line 1728, in _restore_best_loss
    logger.info(" > Starting with loaded last best loss %f", self.best_loss)
Message: ' > Starting with loaded last best loss %f'
Arguments: {'train_loss': 18.22130616851475, 'eval_loss': None}
```

Then the following error occurs at the end of the epoch and training stops:
```
  File ".../trainer/io.py", line 183, in save_best_model
    if current_loss < best_loss:
TypeError: '<' not supported between instances of 'float' and 'dict'
```

This has been observed multiple times:
- Fixes https://github.com/coqui-ai/Trainer/issues/127
- Fixes https://github.com/coqui-ai/TTS/issues/2880
- Fixes https://github.com/coqui-ai/TTS/issues/3069
- Fixes https://github.com/coqui-ai/TTS/issues/3360

There are multiple open PRs to fix some aspects of this issue.
- https://github.com/coqui-ai/Trainer/pull/130
- https://github.com/coqui-ai/Trainer/pull/128
- https://github.com/coqui-ai/Trainer/pull/125

Others have fixed it in their Trainer forks:
- https://github.com/gattilorenz/Trainer/commit/82470312bc40484d3c466879a66b195103501e45
- https://github.com/jmaty/Trainer/commit/dbc77f81d57179c0f5fa716635dfa1376e8bd268

# The reason

This error occurs because #121 changed https://github.com/coqui-ai/Trainer/blob/47781f58d2714d8139dc00f57dbf64bcc14402b7/trainer/trainer.py#L1924 to save the `model_loss` as a dict instead of just a float.
https://github.com/coqui-ai/Trainer/blob/47781f58d2714d8139dc00f57dbf64bcc14402b7/trainer/io.py#L195
still saves a float in `model_loss`, so loading the best model would still work fine. Loading a model via `--restore-path` also works fine because in that case the best loss is reset and not initialised from the saved model.

# This fix

- changes `save_best_model()` to also save a dict with train and eval loss, so that this is consistent everywhere
- ensures that the model loader can handle both float and dict `model_loss` for backwards compatibility
- adds relevant test cases that would have previously failed