### PR TITLE
Fix incorrect path to distribute.py in trainer_utils.py for multi-GPU…

### DIFF
--- a/trainer/trainer_utils.py
+++ b/trainer/trainer_utils.py
@@ -98,7 +98,7 @@ def setup_torch_training_env(
 
     if num_gpus > 1 and (not use_ddp and not args.use_accelerate):
         raise RuntimeError(
-            f" [!] {num_gpus} active GPUs. Define the target GPU by `CUDA_VISIBLE_DEVICES`. For multi-gpu training use `TTS/bin/distribute.py`."
+            f" [!] {num_gpus} active GPUs. Define the target GPU by `CUDA_VISIBLE_DEVICES`. For multi-gpu training use `TTS/utils/distribute.py`."
         )
 
     random.seed(training_seed)


### PR DESCRIPTION
… training error handling

Correct the path to the distribute.py script in trainer_utils.py to properly handle errors related to single-GPU training when multiple GPUs are detected. This update ensures the multi-GPU training guidance points to the right script location, improving usability and preventing confusion during distributed training setup.